### PR TITLE
Update 2.2.md

### DIFF
--- a/2.2.md
+++ b/2.2.md
@@ -110,9 +110,9 @@ Python 中的元组（以及多数其它编程语言中的序列）下标都以 
 >>> def make_rat(n, d):
         return (n, d)
 >>> def numer(x):
-        return getitem(x, 0)
+        return x.__getitem__(0)
 >>> def denom(x):
-        return getitem(x, 1)
+        return x.__getitem__(1)
 ```
 
 用于打印有理数的函数完成了我们对抽象数据结构的实现。


### PR DESCRIPTION
directly call method getitem() will receive a NameError
we can use x.__getitem__(0) or index grammar x[0]